### PR TITLE
bug 1432244 - more python 3.6 fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,4 +87,11 @@ Required environment variables:
 ``PIGEON_AWS_REGION``
     The AWS region to use.
 
-If any of these are missing from the environment, Pigeon will raise a ``KeyError``.
+``PIGEON_ENV``
+    Optional. The name of the environment. This should be all letters with no
+    punctuation. This should be unique between environments. For example,
+    "prod", "stage", and "newstage".
+
+
+If any of these are required, but missing from the environment, Pigeon will
+raise a ``KeyError``.

--- a/pigeon.py
+++ b/pigeon.py
@@ -125,7 +125,8 @@ class Config(object):
         }
 
         client = boto3.client('kms', **kwargs)
-        return client.decrypt(CiphertextBlob=b64decode(data))['Plaintext']
+        text_as_bytes = client.decrypt(CiphertextBlob=b64decode(data))['Plaintext']
+        return text_as_bytes.decode('ascii')
 
     @contextlib.contextmanager
     def override(self, **kwargs):


### PR DESCRIPTION
pika was unhappy with the virtual host--it wants a str. This should fix that.

This also documents `PIGEON_ENV` which was missing before.